### PR TITLE
Add redux to the project, along with some counter boilerplate that we can reshape for later

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,0 +1,3 @@
+import wrapWithProvider from './src/state/providerWrapper';
+
+export const wrapRootElement = wrapWithProvider;

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,0 +1,3 @@
+import wrapWithProvider from './src/state/providerWrapper';
+
+export const wrapRootElement = wrapWithProvider;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3733,6 +3733,15 @@
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.6.tgz",
       "integrity": "sha512-GRTZLeLJ8ia00ZH8mxMO8t0aC9M1N9bN461Z2eaRurJo6Fpa+utgCwLzI4jQHcrdzuzp5WPN9jRwpsCQ1VhJ5w=="
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/http-proxy": {
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.4.tgz",
@@ -3865,6 +3874,17 @@
       "integrity": "sha512-NBMPAxgjpaMooXa51cU1BTgrX6T+hQbMiLm77JhBbfOzPQea3RB5rNpPOD5xGWHIVpGXHd59cltEzIq0qglGcQ==",
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/react-redux": {
+      "version": "7.1.9",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.9.tgz",
+      "integrity": "sha512-mpC0jqxhP4mhmOl3P4ipRsgTgbNofMRXJb08Ms6gekViLj61v1hOZEKWDCyWsdONr6EjEA6ZHXC446wdywDe0w==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "@types/react-transition-group": {
@@ -10886,6 +10906,21 @@
       "integrity": "sha512-9bLtE9frjQhxT9P026Z88IhisoxreixWmPWFGXP4Umq5jp1rEBWXok7A3hduc/Iv0/nI+B1onYunWkjXWvNqtQ==",
       "requires": {
         "@babel/runtime": "^7.10.2"
+      }
+    },
+    "gatsby-plugin-react-redux": {
+      "version": "1.1.0-0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-redux/-/gatsby-plugin-react-redux-1.1.0-0.tgz",
+      "integrity": "sha512-xuwF35hS0aaBzDj7gRk67SYzlT0egdp0giyf/DOuAQTCzioje7RCZt/k3WOO3K6/OoaakgfrwfVOSTTcqYiPMw==",
+      "requires": {
+        "serialize-javascript": "^2.1.0"
+      },
+      "dependencies": {
+        "serialize-javascript": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+          "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ=="
+        }
       }
     },
     "gatsby-plugin-sharp": {
@@ -20225,6 +20260,18 @@
             "object-assign": "^4.1.1"
           }
         }
+      }
+    },
+    "react-redux": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.0.tgz",
+      "integrity": "sha512-EvCAZYGfOLqwV7gh849xy9/pt55rJXPwmYvI4lilPM5rUT/1NxuuN59ipdBksRVSvz0KInbPnp4IfoXJXCqiDA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "hoist-non-react-statics": "^3.3.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.9.0"
       }
     },
     "react-refresh": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@types/enzyme": "^3.10.5",
     "@types/react": "^16.9.41",
     "@types/react-helmet": "^6.0.0",
+    "@types/react-redux": "^7.1.9",
     "@typescript-eslint/parser": "^3.5.0",
     "dotenv": "^8.2.0",
     "eslint": "^7.3.1",
@@ -21,13 +22,16 @@
     "gatsby-plugin-material-ui": "^2.1.9",
     "gatsby-plugin-offline": "^3.2.12",
     "gatsby-plugin-react-helmet": "^3.3.5",
+    "gatsby-plugin-react-redux": "^1.1.0-0",
     "gatsby-plugin-sharp": "^2.6.13",
     "gatsby-source-filesystem": "^2.3.13",
     "gatsby-transformer-sharp": "^2.5.6",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-google-button": "^0.7.1",
-    "react-helmet": "^6.1.0"
+    "react-helmet": "^6.1.0",
+    "react-redux": "^7.2.0",
+    "redux": "^4.0.5"
   },
   "devDependencies": {
     "@types/jest": "^26.0.3",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -43,7 +43,6 @@ export interface IndexProps {
   decCounter: React.MouseEventHandler<HTMLElement>;
 }
 
-// TODO: Fix TS types
 const mapStateToProps = (state: IndexStateMapping): IndexStateMapping => ({
   count: state.count,
 });

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,18 +1,33 @@
 import React from 'react';
+import { connect } from 'react-redux';
+
+// Material UI imports
+import { Button, Typography } from '@material-ui/core';
+
+import { incrementCounter, decrementCounter } from '../state/actions/counter';
 
 import Layout from '../components/layout';
 import SEO from '../components/seo';
 
-const IndexPage: React.FC = () => (
-  <Layout>
-    <SEO title="Home" />
-    <h1>Hi people</h1>
-    <p>Welcome to your new Gatsby site.</p>
-    <p>Now go build something great.</p>
-    <div style={{ maxWidth: `300px`, marginBottom: `1.45rem` }}>
-      Sample Text
-    </div>
-  </Layout>
-);
+const IndexPage: React.FC = ({ count, incCounter, decCounter }: any) => {
+  return (
+    <Layout>
+      <SEO title="Home" />
+      <Typography variant="h3">{count}</Typography>
+      <Button onClick={incCounter}>Increment</Button>
+      <Button onClick={decCounter}>Decrement</Button>
+    </Layout>
+  );
+};
 
-export default IndexPage;
+// TODO: Fix TS types
+const mapStateToProps = (state: any): any => ({
+  count: state.count,
+});
+
+const mapDispatchToProps = (dispatch: any): any => ({
+  incCounter: () => dispatch(incrementCounter()),
+  decCounter: () => dispatch(decrementCounter()),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(IndexPage);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,15 +1,23 @@
-import React from 'react';
+import React, { Dispatch } from 'react';
 import { connect } from 'react-redux';
 
 // Material UI imports
 import { Button, Typography } from '@material-ui/core';
 
-import { incrementCounter, decrementCounter } from '../state/actions/counter';
+import {
+  incrementCounter,
+  decrementCounter,
+  CounterAction,
+} from '../state/actions/counter';
 
 import Layout from '../components/layout';
 import SEO from '../components/seo';
 
-const IndexPage: React.FC = ({ count, incCounter, decCounter }: any) => {
+const IndexPage: React.FC<IndexProps> = ({
+  count,
+  incCounter,
+  decCounter,
+}: IndexProps) => {
   return (
     <Layout>
       <SEO title="Home" />
@@ -20,12 +28,29 @@ const IndexPage: React.FC = ({ count, incCounter, decCounter }: any) => {
   );
 };
 
+export interface IndexStateMapping {
+  count: number;
+}
+
+export interface IndexDispatchMapping {
+  incCounter: React.MouseEventHandler<HTMLElement>;
+  decCounter: React.MouseEventHandler<HTMLElement>;
+}
+
+export interface IndexProps {
+  count: number;
+  incCounter: React.MouseEventHandler<HTMLElement>;
+  decCounter: React.MouseEventHandler<HTMLElement>;
+}
+
 // TODO: Fix TS types
-const mapStateToProps = (state: any): any => ({
+const mapStateToProps = (state: IndexStateMapping): IndexStateMapping => ({
   count: state.count,
 });
 
-const mapDispatchToProps = (dispatch: any): any => ({
+const mapDispatchToProps = (
+  dispatch: Dispatch<CounterAction>
+): IndexDispatchMapping => ({
   incCounter: () => dispatch(incrementCounter()),
   decCounter: () => dispatch(decrementCounter()),
 });

--- a/src/state/actions/counter.ts
+++ b/src/state/actions/counter.ts
@@ -1,9 +1,11 @@
 import { Action } from 'redux';
 
+// Action type string constants
 export const INCREMENT_COUNTER = 'INCREMENT_COUNTER';
 export const DECREMENT_COUNTER = 'DECREMENT_COUNTER';
 
-export function incrementCounter(): Action {
+// Action functions
+export function incrementCounter(): CounterAction {
   return {
     type: INCREMENT_COUNTER,
   };
@@ -14,3 +16,14 @@ export function decrementCounter(): Action {
     type: DECREMENT_COUNTER,
   };
 }
+
+// Action TS types
+export interface IncrementCounter {
+  type: typeof INCREMENT_COUNTER;
+}
+
+export interface DecrementCounter {
+  type: typeof DECREMENT_COUNTER;
+}
+
+export type CounterAction = IncrementCounter | DecrementCounter;

--- a/src/state/actions/counter.ts
+++ b/src/state/actions/counter.ts
@@ -1,0 +1,16 @@
+import { Action } from 'redux';
+
+export const INCREMENT_COUNTER = 'INCREMENT_COUNTER';
+export const DECREMENT_COUNTER = 'DECREMENT_COUNTER';
+
+export function incrementCounter(): Action {
+  return {
+    type: INCREMENT_COUNTER,
+  };
+}
+
+export function decrementCounter(): Action {
+  return {
+    type: DECREMENT_COUNTER,
+  };
+}

--- a/src/state/createStore.ts
+++ b/src/state/createStore.ts
@@ -1,0 +1,5 @@
+import { createStore as reduxCreateStore, Store } from 'redux';
+import counterReducer from './reducers/counter';
+
+const createStore = (): Store => reduxCreateStore(counterReducer);
+export default createStore;

--- a/src/state/providerWrapper.tsx
+++ b/src/state/providerWrapper.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+
+import createStore from './createStore';
+
+// eslint-disable-next-line react/display-name,react/prop-types
+const wrapWithProvider: React.FC<ProviderProps> = ({
+  element,
+}: ProviderProps) => {
+  // Instantiating store in `wrapRootElement` handler ensures:
+  //  - there is fresh store for each SSR page
+  //  - it will be called only once in browser, when React mounts
+  const store = createStore();
+  return <Provider store={store}>{element}</Provider>;
+};
+
+export interface ProviderProps {
+  element: React.FC;
+}
+
+export default wrapWithProvider;

--- a/src/state/reducers/counter.ts
+++ b/src/state/reducers/counter.ts
@@ -1,0 +1,20 @@
+import { Action } from 'redux';
+
+import { INCREMENT_COUNTER, DECREMENT_COUNTER } from '../actions/counter';
+
+const initialState = {
+  count: 0,
+};
+
+const counterReducer = (state = initialState, action: Action): typeof state => {
+  switch (action.type) {
+    case INCREMENT_COUNTER:
+      return { ...state, count: state.count + 1 };
+    case DECREMENT_COUNTER:
+      return { ...state, count: state.count - 1 };
+    default:
+      return state;
+  }
+};
+
+export default counterReducer;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,7 +41,7 @@
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */


### PR DESCRIPTION
This PR does the following:
- Add Redux libs and associated gatsby plugins to the project
- Implement some basic redux counter boilerplate for us to reuse later

Will need to do in a future PR (when we add some API calls/async stuff)
- Add `redux-thunk` or some other async redux helpers for async API calls and things